### PR TITLE
Implement support for deploying a single app

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ Usage
 ----
 
 When used as a bot, just leave a comment in an issue like `reina: d projectzero#nice-feature-branch`.
-Reina will handle all the cleaning once you eventually close it. By executing once again the command,
-the stagings will be replaced with a fresh new deploy.
+Reina will handle all the cleaning once you eventually close it.
+By executing once again the command, the stagings will be replaced with a fresh new deploy.
+You will replace `d` with `r` when you want to deploy only the apps that you have clearly defined
+in the command, which is useful when you want to deploy only the latest version of an application
+that you have already deployed instead of the whole suite.
 
 As a CLI application, execute `$ ruby reina.rb 1234 "projectzero#nice-feature-branch"`.
 

--- a/bin/reina
+++ b/bin/reina
@@ -1,20 +1,53 @@
 #!/usr/bin/env ruby
 require 'reina'
-require 'readline'
+require 'optparse'
 
-reina = Reina::Controller.new(ARGV.dup)
+options = {
+  force: false,
+  strict: false
+}
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: reina [options]"
+
+  opts.on('-f', '--force', 'Delete the existing apps without asking for deletion') do
+    options[:force] = true
+  end
+
+  opts.on('-s', '--strict', 'Enable the strict mode in which only the apps given in the CLI are considered rather than the whole suite') do
+    options[:strict] = true
+  end
+
+  opts.on('-v', '--version', 'Print the version') do
+    puts Reina::VERSION
+    exit
+  end
+end.parse!
+
+reina = Reina::Controller.new(ARGV.dup, options[:strict])
 
 if reina.existing_apps.present?
   puts 'The following apps already exist on Heroku:'
   puts reina.existing_apps.map { |a| "- #{a}" }
-  abort if Readline.readline('Type "OK" to delete the apps above: ', true).strip != 'OK'
+
+  unless options[:force]
+    require 'readline'
+    abort if Readline.readline('Type "OK" to delete the apps above: ', true).strip != 'OK'
+  end
 
   reina.delete_existing_apps!
 end
 
-puts 'Starting deployments...'
+apps_count = reina.apps.size
+
+if apps_count > 1
+  puts "Starting to deploy #{apps_count} apps..."
+else
+  puts "Starting to deploy one app..."
+end
 
 reina.deploy_parallel_apps!
 reina.deploy_non_parallel_apps!
 
-puts 'All the apps have been deployed!'
+s = 's'.freeze if apps_count > 1
+puts "Deployment#{s} finished. Live at #{url}."

--- a/lib/reina/controller.rb
+++ b/lib/reina/controller.rb
@@ -4,6 +4,7 @@ module Reina
 
     def initialize(params, strict = false)
       @params = params
+      @strict = strict
 
       abort 'Please provide $PLATFORM_API' if CONFIG[:platform_api].blank?
       abort 'Given PR number should be greater than 0' if issue_number <= 0
@@ -33,7 +34,8 @@ module Reina
         rescue Git::GitExecuteError => e
           puts "#{app.name}: #{e.message}"
         rescue Exception => e
-          puts "#{app.name}: #{e.response.body}"
+          msg = e.respond_to?(:response) ? e.response.body : e.message
+          puts "#{app.name}: #{msg}"
         end
       end
     end
@@ -45,7 +47,8 @@ module Reina
         rescue Git::GitExecuteError => e
           puts "#{app.name}: #{e.message}"
         rescue Exception => e
-          puts "#{app.name}: #{e.response.body}"
+          msg = e.respond_to?(:response) ? e.response.body : e.message
+          puts "#{app.name}: #{msg}"
         end
       end
     end
@@ -66,6 +69,24 @@ module Reina
       ENV['DYNO'].present?
     end
 
+    def apps
+      return @_apps if @_apps.present?
+
+      # strict is when we only take in consideration the apps
+      # that are in both `params` and `APPS`
+      _apps = if strict
+        app_names = branches.keys
+        APPS.select { |name, _| app_names.include?(name) }
+      else
+        APPS
+      end
+
+      @_apps = _apps.map do |name, project|
+        branch = branches[name.to_s].presence || 'master'.freeze
+        App.new(heroku, name, project, issue_number, branch)
+      end
+    end
+
     private
 
     attr_reader :params, :strict
@@ -80,19 +101,6 @@ module Reina
 
     def branches
       @_branches ||= params.map { |param| param.split('#', 2) }.to_h
-    end
-
-    def apps
-      return @_apps if @_apps.present?
-
-      # strict is when we only take in consideration the apps
-      # that are in both `params` and `APPS`
-      app_names = strict ? branches.keys : APPS.keys
-      _apps = APPS.select { |name, _| app_names.include?(name) }
-      @_apps = _apps.map do |name, project|
-        branch = branches[name.to_s].presence || 'master'.freeze
-        App.new(heroku, name, project, issue_number, branch)
-      end
     end
 
     def deploy!(app)

--- a/lib/reina/github_controller.rb
+++ b/lib/reina/github_controller.rb
@@ -25,6 +25,8 @@ module Reina
 
       if deploy_requested?
         deploy!
+      elsif single_deploy_requested?
+        deploy!(true)
       elsif issue_closed?
         destroy!
       end
@@ -58,21 +60,30 @@ module Reina
       action == 'closed'.freeze
     end
 
-    def deploy!
-      reina = Controller.new(params)
+    def deploy!(strict = false)
+      reina = Controller.new(params, strict)
       should_comment = config[:oauth_token].present?
       reply = ->(msg) { octokit.add_comment(repo_full_name, issue_number, msg) }
       url = deployed_url
 
       fork do
-        reply.call('Starting deployments...') if should_comment
+        apps_count = reina.apps.size
+
+        if should_comment
+          if apps_count > 1
+            reply.call("Starting to deploy #{apps_count} apps...")
+          else
+            reply.call("Starting to deploy one app...")
+          end
+        end
 
         reina.create_netrc if reina.heroku?
         reina.delete_existing_apps!
         reina.deploy_parallel_apps!
         reina.deploy_non_parallel_apps!
 
-        reply.call("Deployment finished. Live at #{url}.") if should_comment
+        s = 's'.freeze if apps_count > 1
+        reply.call("Deployment#{s} finished. Live at #{url}.") if should_comment
       end
     end
 

--- a/lib/reina/github_controller.rb
+++ b/lib/reina/github_controller.rb
@@ -8,7 +8,8 @@ module Reina
   class UnsupportedEventError < StandardError; end
 
   class GitHubController
-    CMD_TRIGGER = 'reina: d '.freeze
+    DEPLOY_TRIGGER = 'reina: d '.freeze
+    SINGLE_DEPLOY_TRIGGER = 'reina: r '.freeze
     EVENTS = %w(issues issue_comment).freeze
 
     def initialize(config)
@@ -46,7 +47,11 @@ module Reina
     end
 
     def deploy_requested?
-      action == 'created'.freeze && comment_body.start_with?(CMD_TRIGGER)
+      action == 'created'.freeze && comment_body.start_with?(DEPLOY_TRIGGER)
+    end
+
+    def single_deploy_requested?
+      action == 'created'.freeze && comment_body.start_with?(SINGLE_DEPLOY_TRIGGER)
     end
 
     def issue_closed?
@@ -102,7 +107,7 @@ module Reina
         issue_number,
         comment_body
           .lines[0]
-          .split(CMD_TRIGGER)[1]
+          .split(/#{DEPLOY_TRIGGER}|#{SINGLE_DEPLOY_TRIGGER}/)[1]
           .split(' ')
           .reject(&:blank?)
       ].flatten

--- a/specs/controller_spec.rb
+++ b/specs/controller_spec.rb
@@ -2,7 +2,8 @@ require_relative 'spec_helper'
 
 describe Reina::Controller do
   let(:params) { [1234, 'a#b', 'c#d'] }
-  let(:instance) { described_class.new(params) }
+  let(:strict) { false }
+  let(:instance) { described_class.new(params, strict) }
   let(:apps) do
     [
       double('App', parallel?: true,


### PR DESCRIPTION
With this PR we get better comments and possibility to activate the `strict` mode, which considers only the given parameters rather than the whole suite.